### PR TITLE
Add release command to Fly deploy config

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -21,3 +21,6 @@ primary_region = 'cdg'
   cpu_kind = 'shared'
   cpus = 1
   memory_mb = 1024
+
+[deploy]
+  release_command = "npm run db:migrate"


### PR DESCRIPTION
Configured the Fly deployment to run 'npm run db:migrate' as a release command, ensuring database migrations are executed during deployment.