### PR TITLE
Install all dependencies in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY . ./
 
 # Install every dependency in package-lock
-RUN npm ci --only=production
+RUN npm ci
 
 EXPOSE 3333
 


### PR DESCRIPTION
Changed npm install command in Dockerfile from production-only to include all dependencies. This ensures both production and development dependencies are installed during the build.